### PR TITLE
Downgrading hazelcast version to mitigate issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Bundle Hazelcast with Zeebe
 
 FROM camunda/zeebe:0.22.1
-ADD https://github.com/zeebe-io/zeebe-hazelcast-exporter/releases/download/0.7.0/zeebe-hazelcast-exporter-0.7.0-jar-with-dependencies.jar /usr/local/zeebe/lib/zeebe-hazelcast-exporter.jar
+ADD https://github.com/zeebe-io/zeebe-hazelcast-exporter/releases/download/0.6.0/zeebe-hazelcast-exporter-0.6.0-jar-with-dependencies.jar /usr/local/zeebe/lib/zeebe-hazelcast-exporter.jar
 RUN chmod 644 /usr/local/zeebe/lib/zeebe-hazelcast-exporter.jar

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 Dockerfiles which create Custom Zeebe images with Hazelcast exporter dependencies: [Docker Repo](https://hub.docker.com/repository/docker/livspaceeng/zeebe)
 
 ### Released versions:
-- **latest** : _Pre-release_ - Zeebe-0.22.x with Hazelcast-0.7.x : _JAVA_VERSION: 11_
-- **v0.22.1.1** : Zeebe-0.22.1 with Hazelcast-0.7.0 : _JAVA_VERSION: 11_
+- **latest** : _Pre-release_ - Zeebe-0.22.x with Hazelcast-0.6.x : _JAVA_VERSION: 11_
+- **v0.22.1.1** : Zeebe-0.22.1 with Hazelcast-0.6.0 : _JAVA_VERSION: 11_
 - **v0.21.1.3** : Zeebe-0.21.1 with Hazelcast-0.6.0 : _JAVA_VERSION: 11_
 - **v0.20.1.2** : Zeebe-0.20.1 with Hazelcast-0.5.0 : _JAVA_VERSION: 1.8_
+
+**Note:** There is an [issue](https://github.com/livspaceeng/zeebe-docker/pull/1) with hazelcast-0.7.0, which needs to be checked before upgrading the version. This issue can be reproduced in dev/alpha environments, but is not coming up in local.


### PR DESCRIPTION
2020-01-21 13:50:15.643 [Broker-1-Exporter-1] [Broker-1-zb-fs-workers-0] DEBUG io.zeebe.broker.exporter - Open exporter with id 'hazelcast'
2020-01-21 13:50:15.674 [GatewayTopologyManager] [Broker-1-zb-actors-0] DEBUG io.zeebe.gateway - Received REACHABILITY_CHANGED for broker 0, do nothing.
2020-01-21 13:50:15.674 [Broker-1-TopologyManager] [Broker-1-zb-actors-0] DEBUG io.zeebe.broker.clustering - Received REACHABILITY_CHANGED from member 0, was not handled.
Jan 21, 2020 1:50:15 PM com.hazelcast.instance.HazelcastInstanceFactory
WARNING: Hazelcast is starting in a Java modular environment (Java 9 and newer) but without proper access to required Java packages. Use additional Java arguments to provide Hazelcast access to Java internal API. The internal API access is used to get the best performance results. Arguments to be used:
 --add-modules java.se --add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/sun.nio.ch=ALL-UNNAMED --add-opens java.management/sun.management=ALL-UNNAMED --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED
2020-01-21 13:50:15.706 [Broker-1-Exporter-1] [Broker-1-zb-fs-workers-0] INFO  com.hazelcast.instance.AddressPicker - [LOCAL] [dev] [3.12.5] Prefer IPv4 stack is true, prefer IPv6 addresses is false
2020-01-21 13:50:15.710 [Broker-1-Exporter-1] [Broker-1-zb-fs-workers-0] INFO  com.hazelcast.instance.AddressPicker - [LOCAL] [dev] [3.12.5] Picked [100.117.64.19]:5701, using socket ServerSocket[addr=/0.0.0.0,localport=5701], bind any local is true
2020-01-21 13:50:15.716 [Broker-1-Exporter-1] [Broker-1-zb-fs-workers-0] ERROR io.zeebe.util.actor - Actor failed in phase 'STARTED'. Continue with next job.
com.hazelcast.core.HazelcastException: ServiceLoader didn't find any services registered under com.hazelcast.instance.NodeExtension
	at com.hazelcast.instance.NodeExtensionFactory.create(NodeExtensionFactory.java:86) ~[zeebe-hazelcast-exporter.jar:0.7.0]
	at com.hazelcast.instance.DefaultNodeContext.createNodeExtension(DefaultNodeContext.java:59) ~[zeebe-hazelcast-exporter.jar:0.7.0]
	at com.hazelcast.instance.Node.<init>(Node.java:223) ~[zeebe-hazelcast-exporter.jar:0.7.0]
	at com.hazelcast.instance.HazelcastInstanceImpl.createNode(HazelcastInstanceImpl.java:161) ~[zeebe-hazelcast-exporter.jar:0.7.0]
	at com.hazelcast.instance.HazelcastInstanceImpl.<init>(HazelcastInstanceImpl.java:131) ~[zeebe-hazelcast-exporter.jar:0.7.0]
	at com.hazelcast.instance.HazelcastInstanceFactory.constructHazelcastInstance(HazelcastInstanceFactory.java:228) ~[zeebe-hazelcast-exporter.jar:0.7.0]
	at com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance(HazelcastInstanceFactory.java:207) ~[zeebe-hazelcast-exporter.jar:0.7.0]
	at com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance(HazelcastInstanceFactory.java:157) ~[zeebe-hazelcast-exporter.jar:0.7.0]
	at com.hazelcast.core.Hazelcast.newHazelcastInstance(Hazelcast.java:57) ~[zeebe-hazelcast-exporter.jar:0.7.0]
	at io.zeebe.hazelcast.exporter.HazelcastExporter.open(HazelcastExporter.java:81) ~[zeebe-hazelcast-exporter.jar:0.7.0]
	at io.zeebe.broker.exporter.stream.ExporterDirector.onSnapshotRecovered(ExporterDirector.java:225) ~[zeebe-broker-0.22.1.jar:0.22.1]
	at io.zeebe.broker.exporter.stream.ExporterDirector.onActorStarted(ExporterDirector.java:140) ~[zeebe-broker-0.22.1.jar:0.22.1]
	at io.zeebe.util.sched.ActorJob.invoke(ActorJob.java:73) ~[zeebe-util-0.22.1.jar:0.22.1]
	at io.zeebe.util.sched.ActorJob.execute(ActorJob.java:39) [zeebe-util-0.22.1.jar:0.22.1]
	at io.zeebe.util.sched.ActorTask.execute(ActorTask.java:115) [zeebe-util-0.22.1.jar:0.22.1]
	at io.zeebe.util.sched.ActorThread.executeCurrentTask(ActorThread.java:107) [zeebe-util-0.22.1.jar:0.22.1]
	at io.zeebe.util.sched.ActorThread.doWork(ActorThread.java:91) [zeebe-util-0.22.1.jar:0.22.1]
	at io.zeebe.util.sched.ActorThread.run(ActorThread.java:195) [zeebe-util-0.22.1.jar:0.22.1]